### PR TITLE
Modernize PHP Support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - 7.2
-          - 7.3
-          - 7.4
           - 8.0
           - 8.1
           - 8.2
+          - 8.3
+          - 8.4
         dependencies:
           - lowest
           - highest

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ Files in the file system are never deleted.
 #### Example
 
 ```PHP
+use Doctrine\ORM\Mapping as ORM;
+use TS\Web\Resource\Entity\EmbeddedResource;
+use TS\Web\Resource\ResourceInterface;
 
-/** @ORM\Entity() */
+#[ORM\Entity]
 class TestEntity
 {
-
-    /**
-     * @ORM\Embedded(class = EmbeddedResource::class )
-     */
+    #[ORM\Embedded(class: EmbeddedResource::class)]
     private $file;
 
 

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
   "require-dev": {
     "phpunit/phpunit": "^9.6.20",
     "mikey179/vfsstream": "^1.6.11",
-    "symfony/cache": "^5.4 || 6.4",
-    "doctrine/annotations": "^2.0"
+    "symfony/cache": "^5.4 || 6.4"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": "^8.0",
     "timostamm/web-resource": "^2.0",
-    "doctrine/orm": "^2.6"
+    "doctrine/orm": "^2.11"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6.20",

--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,14 @@
   "type": "library",
   "license": "MIT",
   "require": {
-    "php": "^7.2 || ^8.0",
-    "timostamm/web-resource": "^1.1.0",
+    "php": "^8.0",
+    "timostamm/web-resource": "^2.0",
     "doctrine/orm": "^2.6"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5.23 || ^9",
+    "phpunit/phpunit": "^9.6.20",
     "mikey179/vfsstream": "^1.6.11",
-    "symfony/cache": ">=4.4 < 6",
+    "symfony/cache": "^5.4 || 6.4",
     "doctrine/annotations": "^2.0"
   },
   "autoload": {

--- a/src/Entity/EmbeddedResource.php
+++ b/src/Entity/EmbeddedResource.php
@@ -16,9 +16,7 @@ use TS\Web\Resource\ORMResourceHandler;
 use TS\Web\Resource\ResourceInterface;
 
 
-/**
- * @ORM\Embeddable()
- */
+#[ORM\Embeddable]
 class EmbeddedResource implements ResourceInterface
 {
 
@@ -35,34 +33,22 @@ class EmbeddedResource implements ResourceInterface
     }
 
 
-    /**
-     * @ORM\Column(type="string", length=64, nullable=true)
-     */
+    #[ORM\Column(type: 'string', length: 64, nullable: true)]
     protected $hash;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     protected $filename;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     protected $mimetype;
 
-    /**
-     * @ORM\Column(type="integer", nullable=true)
-     */
+    #[ORM\Column(type: 'integer', nullable: true)]
     protected $length;
 
-    /**
-     * @ORM\Column(type="datetime", nullable=true)
-     */
+    #[ORM\Column(type: 'datetime', nullable: true)]
     protected $lastmodfied;
 
-    /**
-     * @ORM\Column(type="array", name="attributes", nullable=true)
-     */
+    #[ORM\Column(type: 'array', name: 'attributes', nullable: true)]
     protected $attributes;
 
 

--- a/tests/DatabaseSetupTrait.php
+++ b/tests/DatabaseSetupTrait.php
@@ -112,7 +112,7 @@ trait DatabaseSetupTrait
         // Create a simple "default" Doctrine ORM configuration for Annotations
         $isDevMode = true;
 
-        $config = Setup::createAnnotationMetadataConfiguration($entityDirectories, $isDevMode, null, null, false);
+        $config = Setup::createAttributeMetadataConfiguration($entityDirectories, $isDevMode, null, null, false);
 
         // Database configuration parameters
         $connectionParams = array(

--- a/tests/Entity/TestEntity.php
+++ b/tests/Entity/TestEntity.php
@@ -12,32 +12,25 @@ use Doctrine\ORM\Mapping as ORM;
 use TS\Web\Resource\ResourceInterface;
 
 
-/**
- * @ORM\Entity()
- */
+#[ORM\Entity]
 class TestEntity
 {
 
 
     /**
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
-     *
      * Initial value -1: @see https://github.com/doctrine/doctrine2/issues/4584
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     private $id = -1;
 
 
-    /**
-     * @ORM\Embedded(class = EmbeddedResource::class )
-     */
+    #[ORM\Embedded(class: EmbeddedResource::class)]
     private $file;
 
 
-    /**
-     * @ORM\Embedded(class = EmbeddedResource::class )
-     */
+    #[ORM\Embedded(class: EmbeddedResource::class)]
     private $other;
 
 


### PR DESCRIPTION
This PR modernizes the codebase by dropping legacy PHP 7 support, updating to current Symfony versions, and migrating from Doctrine annotations to PHP 8 attributes.

## Changes

- Add PHP 8.3 and 8.4 support
- Migrate from Doctrine annotations to attributes
- Add Symfony 6 compatibility
- Update CI workflow to test against current PHP versions


## Breaking Changes

- **Dropped PHP 7 support** - minimum PHP version is now 8.0
- **Dropped Symfony 4**: now requires Symfony 5.4 or 6.4
