### PR TITLE
Restore support for Doctrine Annotations for Symfony v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ This package uses timostamm/web-resource for file representation.
 Files in the file system are never deleted.
 
 
-#### Example
+## Example
+
+The library supports both **PHP 8 Attributes** and **Doctrine Annotations** for mapping definitions.
+
+### Using PHP 8 Attributes
 
 ```PHP
 use Doctrine\ORM\Mapping as ORM;
@@ -47,6 +51,45 @@ $e->setFile(Resource::fromFile(__FILE__));
 
 $em->persist($e);
 $em->flush($e);
+```
+
+### Using Doctrine Annotations
+
+```PHP
+use Doctrine\ORM\Mapping as ORM;
+use TS\Web\Resource\Entity\EmbeddedResource;
+use TS\Web\Resource\ResourceInterface;
+
+/**
+ * @ORM\Entity()
+ */
+class TestEntity
+{
+    /**
+     * @ORM\Embedded(class = EmbeddedResource::class)
+     */
+    private $file;
 
 
+    public function getFile(): ?ResourceInterface
+    {
+        return $this->file;
+    }
+
+    public function setFile(?ResourceInterface $resource): void
+    {
+        $this->file = EmbeddedResource::create($resource);
+    }
+
+}
+
+
+$em->getEventManager()
+    ->addEventSubscriber(new ORMResourceHandler(new HashStorage($storageDir)));
+
+$e = new TestEntity();
+$e->setFile(Resource::fromFile(__FILE__));
+
+$em->persist($e);
+$em->flush($e);
 ```

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "doctrine/orm": "^2.11"
   },
   "require-dev": {
+    "doctrine/annotations": "^2.0",
     "phpunit/phpunit": "^9.6.20",
     "mikey179/vfsstream": "^1.6.11",
     "symfony/cache": "^5.4 || 6.4"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
     <ini name="error_reporting" value="-1"/>
     <!--<var name="DB_URL" value="mysql://root@localhost/w2p_core" />-->
     <var name="DB_URL" value="sqlite:///:memory:"/>
+    <env name="TEST_METADATA_DRIVER" value="attribute"/>
   </php>
   <testsuites>
     <testsuite name="Project Test Suite">

--- a/src/Entity/EmbeddedResource.php
+++ b/src/Entity/EmbeddedResource.php
@@ -16,6 +16,9 @@ use TS\Web\Resource\ORMResourceHandler;
 use TS\Web\Resource\ResourceInterface;
 
 
+/**
+ * @ORM\Embeddable()
+ */
 #[ORM\Embeddable]
 class EmbeddedResource implements ResourceInterface
 {
@@ -33,21 +36,39 @@ class EmbeddedResource implements ResourceInterface
     }
 
 
+    /**
+     * @ORM\Column(type="string", length=64, nullable=true)
+     */
     #[ORM\Column(type: 'string', length: 64, nullable: true)]
     protected $hash;
 
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     #[ORM\Column(type: 'string', nullable: true)]
     protected $filename;
 
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     #[ORM\Column(type: 'string', nullable: true)]
     protected $mimetype;
 
+    /**
+     * @ORM\Column(type="integer", nullable=true)
+     */
     #[ORM\Column(type: 'integer', nullable: true)]
     protected $length;
 
+    /**
+     * @ORM\Column(type="datetime", nullable=true)
+     */
     #[ORM\Column(type: 'datetime', nullable: true)]
     protected $lastmodfied;
 
+    /**
+     * @ORM\Column(type="array", name="attributes", nullable=true)
+     */
     #[ORM\Column(type: 'array', name: 'attributes', nullable: true)]
     protected $attributes;
 

--- a/tests/DatabaseSetupTrait.php
+++ b/tests/DatabaseSetupTrait.php
@@ -109,10 +109,17 @@ trait DatabaseSetupTrait
      */
     private function createEntityManager(array $entityDirectories): EntityManager
     {
-        // Create a simple "default" Doctrine ORM configuration for Annotations
         $isDevMode = true;
 
-        $config = Setup::createAttributeMetadataConfiguration($entityDirectories, $isDevMode, null, null, false);
+        // Support both attribute and annotation drivers
+        // Can be configured via TEST_METADATA_DRIVER environment variable
+        $driver = $_ENV['TEST_METADATA_DRIVER'] ?? 'attribute';
+
+        if ($driver === 'annotation') {
+            $config = Setup::createAnnotationMetadataConfiguration($entityDirectories, $isDevMode, null, null, false);
+        } else {
+            $config = Setup::createAttributeMetadataConfiguration($entityDirectories, $isDevMode, null, null, false);
+        }
 
         // Database configuration parameters
         $connectionParams = array(

--- a/tests/Entity/TestEntity.php
+++ b/tests/Entity/TestEntity.php
@@ -12,12 +12,19 @@ use Doctrine\ORM\Mapping as ORM;
 use TS\Web\Resource\ResourceInterface;
 
 
+/**
+ * @ORM\Entity()
+ */
 #[ORM\Entity]
 class TestEntity
 {
 
 
     /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     *
      * Initial value -1: @see https://github.com/doctrine/doctrine2/issues/4584
      */
     #[ORM\Id]
@@ -26,10 +33,16 @@ class TestEntity
     private $id = -1;
 
 
+    /**
+     * @ORM\Embedded(class = EmbeddedResource::class)
+     */
     #[ORM\Embedded(class: EmbeddedResource::class)]
     private $file;
 
 
+    /**
+     * @ORM\Embedded(class = EmbeddedResource::class)
+     */
     #[ORM\Embedded(class: EmbeddedResource::class)]
     private $other;
 


### PR DESCRIPTION
Support for Doctrine Annotations was removed in  [v2.0.0](https://github.com/timostamm/orm-resource/commit/f8da63d7fa3517d2b51e2019a741c23f9c1c5681)
However, Symfony v5 projects may still depend on annotations, so this update restores support to maintain backward compatibility.